### PR TITLE
chore: add minimum permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   jest:
     name: Jest


### PR DESCRIPTION
## Summary

最小権限の `permissions:` ブロックを追加

## Changes

- `.github/workflows/ci.yml`: `actions/checkout` のみ使用しているため、workflow レベルで `permissions: { contents: read }` を付与