### PR TITLE
chore: deny lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+save-exact=true


### PR DESCRIPTION
## Summary

### What

`.npmrc` (新規): `ignore-scripts=true` + `save-exact=true` — install 時の lifecycle script を block する kill switch

### Why

Security 対策